### PR TITLE
critic report 20250808

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,23 @@
+name: Smoke Test (curl)
+
+on:
+  workflow_run:
+    workflows: ["Deploy to GitHub Pages"]
+    types: ["completed"]
+
+jobs:
+  curl-check:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check site is live
+        run: |
+          set -euo pipefail
+          BASE="https://dirkenglund.github.io/20250080.joyce-slides-artifact/"
+          echo "GET $BASE" && curl -fsSIL "$BASE" | cat
+          HTML=$(curl -fsS "$BASE")
+          echo "$HTML" | grep -q 'unpkg.com/reveal.js' || (echo 'reveal.js not found' && exit 1)
+          echo "$HTML" | grep -q 'pdf.min.mjs' || (echo 'pdf.js not found' && exit 1)
+          echo "$HTML" | grep -q 'drive.google.com/uc?export=download' || echo 'Drive link not detected (may be using local slides.pdf)'
+
+

--- a/CRITIC_REPORT.md
+++ b/CRITIC_REPORT.md
@@ -1,0 +1,84 @@
+🚨 CRITIC AGENT ANALYSIS
+====================
+
+Verdict: APPROVED WITH NOTES
+Confidence: 88%
+
+Issues Found:
+1. External CDN dependencies without pinning or SRI
+   - Evidence: `docs/index.html` loads `reveal.js`, plugins, Google Fonts, and `pdf.js` directly from CDNs without Subresource Integrity (SRI) or self-hosting.
+   - Risk: Supply-chain alteration can impact determinism and integrity.
+
+2. Hard-coded Google Drive file identifier
+   - Evidence: `DRIVE_FILE_ID = '1AMERqqv3CZsD85Ig2AP0MfIkSfMl_7wo'` in `docs/index.html`.
+   - Risk: Content mutability outside repo; breakage if the Drive file changes permissions or ID is rotated.
+
+3. Missing CSP and security headers for static site
+   - Evidence: No Content Security Policy or referrer policy configured. GitHub Pages can set headers via `_headers` or repository config, but none present.
+   - Risk: Reduced defense-in-depth for XSS/asset injection.
+
+4. Lack of automated tests or basic smoke checks
+   - Evidence: No test harness to validate rendering of first slide or CDN availability. CI only deploys.
+   - Risk: Silent failure if external PDF cannot be fetched or if plugin API changes.
+
+5. Accessibility and performance checks not enforced
+   - Evidence: No Lighthouse/axe CI step.
+   - Risk: Regressions go undetected.
+
+Positive Findings:
+- No use of `eval`, `exec`, shell invocation, or unsafe deserialization detected.
+- Minimal static footprint; clear separation under `docs/` with restricted GitHub Pages workflow permissions.
+- Fallback path exists to Google Drive iframe when `pdf.js` fetch fails.
+
+Required Actions:
+- Pin CDN assets or self-host with integrity controls
+  - Add SRI hashes to `<script>`/`<link>` tags or vendor assets into `docs/vendor/` and reference locally.
+- External content immutability
+  - Mirror `slides.pdf` into the repo (`docs/slides.pdf`) and read from a relative path; remove dependence on Google Drive ID.
+- Add basic CI smoke tests
+  - Headless check to ensure first slide canvas renders (or Drive iframe fallback appears) using Playwright/Puppeteer.
+- Add a strict CSP for GitHub Pages
+  - Example (adjust for needed origins): `default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'self';` when self-hosting assets.
+- Add accessibility and performance checks
+  - Run Lighthouse CI and axe in CI, fail on regressions beyond thresholds.
+
+Evidence Needed for Closure:
+- Git commit hash that vendors assets or adds SRI and replaces Drive dependency with local `docs/slides.pdf`.
+- CI logs showing passing smoke test on render.
+- Lighthouse report artifact and axe results attached to the CI run.
+
+Traceability (Files Reviewed):
+- `.github/workflows/pages.yml` — deploy only; permissions set to `contents: read`, `pages: write`, `id-token: write`.
+- `docs/index.html` — primary logic, external CDNs, annotation overlay, `pdf.js` rendering.
+- `docs/theme.css` — presentation overrides only.
+- `docs/robots.txt` — allows crawling.
+
+Risk Register:
+- Supply chain (Medium): Unpinned CDNs. Mitigate via SRI or vendoring.
+- Availability (Medium): Remote Drive asset dependency. Mitigate by bundling `slides.pdf` locally.
+- Security headers (Low→Medium): Absent CSP; add static headers for Pages.
+
+Suggested Tests:
+1. Rendering smoke test
+   - Load `docs/index.html` via `file://` and via a local server; assert at least one `canvas.pdf-canvas` has `width>0` within 5s, or Drive iframe exists.
+2. Resize responsiveness
+   - Trigger `resize` and assert re-render occurs (canvas size changes or `renderedPages` cleared/repopulated).
+3. Annotation overlay
+   - Toggle annotate, draw line, assert pixel buffer differs, clear, assert cleared.
+4. Offline run
+   - Block network; verify graceful fallback messaging (expect failure path) and no JS exceptions uncaught.
+
+Uncertainty Quantification:
+- Primary operational risk stems from third-party availability; with vendoring, residual risk becomes low. Without it, site reliability contingent on multiple CDNs and Google Drive uptime.
+
+Appendix: Minimal CSP (when assets are vendored locally)
+```
+default-src 'self';
+img-src 'self' data:;
+style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+font-src https://fonts.gstatic.com;
+script-src 'self';
+frame-src 'self';
+```
+
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' https://unpkg.com https://cdnjs.cloudflare.com; connect-src 'self' https://drive.google.com https://*.googleusercontent.com; frame-src https://drive.google.com; worker-src 'self' blob:; upgrade-insecure-requests" />
     <title>Interactive Slides</title>
     <!-- Reveal.js core CSS -->
     <link rel="stylesheet" href="https://unpkg.com/reveal.js@5/dist/reveal.css" />
@@ -90,6 +91,7 @@
       <button id="toggleAnnotate" title="Toggle annotation overlay (A)">Annotate</button>
       <button id="clearAnnotate" title="Clear annotations (C)">Clear</button>
       <button id="helpBtn" title="Help">Help</button>
+      <a id="downloadBtn" href="#" target="_blank" rel="noopener" title="Download slides (opens in new tab)"><button>Download</button></a>
     </div>
     <canvas id="annotationCanvas"></canvas>
     <div class="hint">Keys: A = annotate, C = clear, S = speaker notes, Alt+Click = zoom</div>
@@ -111,8 +113,12 @@
 
       const slidesRoot = document.getElementById('slides');
       const DRIVE_FILE_ID = '1AMERqqv3CZsD85Ig2AP0MfIkSfMl_7wo';
-      const pdfUrl = `https://drive.google.com/uc?export=download&id=${DRIVE_FILE_ID}`;
+      const params = new URLSearchParams(window.location.search);
+      const overridePdf = params.get('pdf');
+      const localPdf = './slides.pdf';
+      const driveDownload = `https://drive.google.com/uc?export=download&id=${DRIVE_FILE_ID}`;
       const drivePreviewUrl = `https://drive.google.com/file/d/${DRIVE_FILE_ID}/preview`;
+      const pdfUrl = overridePdf || localPdf || driveDownload;
 
       // Initialize Reveal early (content will be injected later)
       const deck = new window.Reveal({
@@ -199,6 +205,9 @@
           renderedPages.clear();
           rerenderVisible(pdfDoc);
         });
+        // Wire download button
+        const dl = document.getElementById('downloadBtn');
+        if (dl) dl.href = pdfUrl;
       }).catch((err) => {
         console.warn('Falling back to Google Drive preview iframe due to PDF fetch error:', err);
         // Fallback: embed Drive preview iframe
@@ -215,6 +224,8 @@
         section.appendChild(container);
         slidesRoot.appendChild(section);
         deck.sync();
+        const dl = document.getElementById('downloadBtn');
+        if (dl) dl.href = driveDownload;
       });
 
       // Simple annotation overlay

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,9 @@
       import { getDocument } from 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.7.76/pdf.min.mjs';
 
       const slidesRoot = document.getElementById('slides');
-      const pdfUrl = './slides.pdf';
+      const DRIVE_FILE_ID = '1AMERqqv3CZsD85Ig2AP0MfIkSfMl_7wo';
+      const pdfUrl = `https://drive.google.com/uc?export=download&id=${DRIVE_FILE_ID}`;
+      const drivePreviewUrl = `https://drive.google.com/file/d/${DRIVE_FILE_ID}/preview`;
 
       // Initialize Reveal early (content will be injected later)
       const deck = new window.Reveal({
@@ -197,6 +199,22 @@
           renderedPages.clear();
           rerenderVisible(pdfDoc);
         });
+      }).catch((err) => {
+        console.warn('Falling back to Google Drive preview iframe due to PDF fetch error:', err);
+        // Fallback: embed Drive preview iframe
+        const section = document.createElement('section');
+        const container = document.createElement('div');
+        container.className = 'pdf-slide';
+        const iframe = document.createElement('iframe');
+        iframe.src = drivePreviewUrl;
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+        iframe.style.border = '0';
+        iframe.allow = 'autoplay';
+        container.appendChild(iframe);
+        section.appendChild(container);
+        slidesRoot.appendChild(section);
+        deck.sync();
       });
 
       // Simple annotation overlay


### PR DESCRIPTION
- **docs: add slides.pdf for live rendering**
- **docs: load slides from Google Drive (with preview fallback)**
- **chore(critic): add rigorous Critic Agent analysis with actionable security and reliability recommendations**
- **chore: remove docs/slides.pdf from VCS to avoid GH push errors**
- **fix(critic): add CSP, download button, ?pdf= override; add curl smoke CI**
